### PR TITLE
add permission endpoints for OneDrive API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Currently, **go-onedrive requires Golang version 1.15 or greater**.  go-onedrive
 ## Installation ##
 
 ```bash
-go get github.com/goh-chunlin/go-onedrive/onedrive
+go get github.com/goh-chunlin/go-onedrive
 ```
 
 ## Usage ##

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Hence, API methods will likely be implemented in the order that they are needed 
 
 ## Sensei Projects ##
 
-Special thanks to the following projects for providing useful references to me on this library.
+Special thanks go to the following projects for providing useful references which help me in the development of this library.
 - [google/go-github](https://github.com/google/go-github);
 - [ggordan/go-onedrive](https://github.com/ggordan/go-onedrive);
 - [googleapis/google-api-go-client](https://github.com/googleapis/google-api-go-client).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/goh-chunlin/go-onedrive
+module github.com/kiddom/go-onedrive
 
 go 1.15
 

--- a/onedrive/onedrive.go
+++ b/onedrive/onedrive.go
@@ -36,10 +36,11 @@ type Client struct {
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
 
 	// Services used for talking to different parts of the OneDrive API.
-	Drives        *DrivesService
-	DriveItems    *DriveItemsService
-	DriveSearch   *DriveSearchService
-	DriveAsyncJob *DriveAsyncJobService
+	Drives           *DrivesService
+	DriveItems       *DriveItemsService
+	DriveSearch      *DriveSearchService
+	DriveAsyncJob    *DriveAsyncJobService
+	DrivePermissions *PermissionService
 }
 
 // NewClient returns a new OneDrive API client. If a nil httpClient is
@@ -60,6 +61,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.DriveItems = (*DriveItemsService)(&c.common)
 	c.DriveSearch = (*DriveSearchService)(&c.common)
 	c.DriveAsyncJob = (*DriveAsyncJobService)(&c.common)
+	c.DrivePermissions = (*PermissionService)(&c.common)
 
 	return c
 }

--- a/onedrive/permission.go
+++ b/onedrive/permission.go
@@ -1,0 +1,80 @@
+package onedrive
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// PermissionService handles permission settings of a drive item
+//
+// OneDrive API docs: https://docs.microsoft.com/en-us/onedrive/developer/rest-api/resources/permission?view=odsp-graph-online
+type PermissionService service
+
+// Permission is the permission of a drive item.
+type Permission struct {
+	ID        string      `json:"id"`
+	GrantedTo interface{} `json:"grantedTo"`
+	Link      SharingLink `json:"link"`
+	Roles     []string    `json:"roles"`
+}
+
+// CreateShareLinkRequest is the request for creating a share link.
+type CreateShareLinkRequest struct {
+	Type  string `json:"type"`  // The type of sharing link to create. Either view, edit, or embed.
+	Scope string `json:"scope"` // Optional. The scope of link to create. Either anonymous or organization.
+}
+
+// SharingLink resource groups link-related data items into a single structure.
+// Ref: https://docs.microsoft.com/en-us/onedrive/developer/rest-api/resources/sharinglink?view=odsp-graph-online
+type SharingLink struct {
+	Type  string `json:"type"`  // The type of sharing link to create. Either view, edit, or embed.
+	Scope string `json:"scope"` // Optional. The scope of link to create. Either anonymous or organization.
+	URL   string `json:"webUrl"`
+}
+
+// CreateShareLink will create a new sharing link if the specified link type doesn't already exist for the calling application.
+// If a sharing link of the specified type already exists for the app, the existing sharing link will be returned.
+//
+// OneDrive API docs: https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_createlink?view=odsp-graph-online
+func (s *PermissionService) CreateShareLink(ctx context.Context, itemID, permissionType, permissionScope string) (*Permission, error) {
+	apiURL := fmt.Sprintf("me/drive/items/%s/createLink", itemID)
+
+	body := &CreateShareLinkRequest{Type: permissionType, Scope: permissionScope}
+	req, err := s.client.NewRequest(http.MethodPost, apiURL, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var oneDriveResponse *Permission
+	err = s.client.Do(ctx, req, false, &oneDriveResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return oneDriveResponse, nil
+}
+
+// ListPermissionsResponse is the response of list permissions of a drive item
+type ListPermissionsResponse struct {
+	Value []Permission `json:"value"`
+}
+
+// List lists the effective sharing permissions of on a DriveItem.
+// OneDrive API docs:  https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_list_permissions?view=odsp-graph-online
+func (s *PermissionService) List(ctx context.Context, itemID string) ([]Permission, error) {
+	apiURL := fmt.Sprintf("me/drive/items/%s/permissions", itemID)
+
+	req, err := s.client.NewRequest(http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var oneDriveResponse *ListPermissionsResponse
+	err = s.client.Do(ctx, req, false, &oneDriveResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return oneDriveResponse.Value, nil
+}

--- a/onedrive/permission_test.go
+++ b/onedrive/permission_test.go
@@ -1,0 +1,66 @@
+package onedrive
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestCreateSharingLink(t *testing.T) {
+	client, mux, _, teardown := setup()
+
+	defer teardown()
+
+	jsonData := getTestDataFromFile(t, "fake_permission.json")
+	mux.HandleFunc("/me/drive/items/1/createLink", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		fmt.Fprint(w, string(jsonData))
+	})
+
+	ctx := context.Background()
+	gotOneDriveResponse, err := client.DrivePermissions.CreateShareLink(ctx, "1", "read", "anonymous")
+	if err != nil {
+		t.Errorf("CreateShareLink returned error: %v", err)
+	}
+
+	var wantDriveItem *Permission
+	if err := json.Unmarshal(jsonData, &wantDriveItem); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(gotOneDriveResponse, wantDriveItem) {
+		t.Errorf("CreateShareLink returned %+v, want %+v", gotOneDriveResponse, wantDriveItem)
+	}
+}
+
+func TestListPermissions(t *testing.T) {
+	client, mux, _, teardown := setup()
+
+	defer teardown()
+
+	jsonData := getTestDataFromFile(t, "fake_permissions.json")
+	mux.HandleFunc("/me/drive/items/1/permissions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		fmt.Fprint(w, string(jsonData))
+	})
+
+	ctx := context.Background()
+	gotOneDriveResponse, err := client.DrivePermissions.List(ctx, "1")
+	if err != nil {
+		t.Errorf("List returned error: %v", err)
+	}
+
+	var wantDriveItem *ListPermissionsResponse
+	if err := json.Unmarshal(jsonData, &wantDriveItem); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(gotOneDriveResponse, wantDriveItem.Value) {
+		t.Errorf("List returned %+v, want %+v", gotOneDriveResponse, wantDriveItem)
+	}
+}

--- a/onedrive/testdata/fake_permission.json
+++ b/onedrive/testdata/fake_permission.json
@@ -1,0 +1,13 @@
+{
+    "id": "123ABC",
+    "roles": ["write"],
+    "link": {
+        "type": "view",
+        "scope": "anonymous",
+        "webUrl": "https://1drv.ms/A6913278E564460AA616C71B28AD6EB6",
+        "application": {
+            "id": "1234",
+            "displayName": "Sample Application"
+        }
+    }
+}

--- a/onedrive/testdata/fake_permissions.json
+++ b/onedrive/testdata/fake_permissions.json
@@ -1,0 +1,39 @@
+
+{
+    "value": [
+        {
+            "id": "1",
+            "roles": ["write"],
+            "link": {
+                "webUrl": "https://onedrive.live.com/redir?resid=5D33DD65C6932946!70859&authkey=!AL7N1QAfSWcjNU8&ithint=folder%2cgif",
+                "type": "edit"
+            }
+        },
+        {
+            "id": "2",
+            "roles": ["write"],
+            "grantedTo": {
+                "user": {
+                    "id": "5D33DD65C6932946",
+                    "displayName": "John Doe"
+                }
+            },
+            "inheritedFrom": {
+                "driveId": "1234567890ABD",
+                "id": "1234567890ABC!123",
+                "path": "/drive/root:/Documents" }
+        },
+        {
+            "id": "3",
+            "roles": ["write"],
+            "link": {
+                "webUrl": "https://onedrive.live.com/redir?resid=5D33DD65C6932946!70859&authkey=!AL7N1QAfSWcjNU8&ithint=folder%2cgif",
+                "type": "edit",
+                "application": {
+                    "id": "12345",
+                    "displayName": "Contoso Time Manager"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This PR is to add two permission endpoints : createShareLink & ListPermissions

REF
https://docs.microsoft.com/en-us/onedrive/developer/rest-api/resources/permission?view=odsp-graph-online

