### PR TITLE
Fix panic at failed error message decode

### DIFF
--- a/onedrive/onedrive.go
+++ b/onedrive/onedrive.go
@@ -214,7 +214,9 @@ func (c *Client) Do(ctx context.Context, req *http.Request, isUsingPlainHttpClie
 		responseBodyReader := bytes.NewReader(responseBody)
 
 		var oneDriveError *ErrorResponse
-		json.NewDecoder(responseBodyReader).Decode(&oneDriveError)
+		if err = json.NewDecoder(responseBodyReader).Decode(&oneDriveError); err != nil {
+			return err
+		}
 
 		if oneDriveError.Error != nil {
 			if oneDriveError.Error.InnerError != nil {


### PR DESCRIPTION
I've witnessed such error in logs
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1455d5f]

goroutine 1 [running]:
github.com/goh-chunlin/go-onedrive/onedrive.(*Client).Do(0xc0001d2400, 0x1a1f8c8, 0xc000124000, 0xc000740900, 0x0, 0x15776a0, 0xc00013e018, 0x0, 0x0)
	/.../pkg/mod/github.com/goh-chunlin/go-onedrive@v1.1.0/onedrive/onedrive.go:219 +0x69f
```
This PR aims to:
a) prevent panic
b) allow investigate failed decode